### PR TITLE
Improve reproducibility, docs, and project scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a problem with the pipeline
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what went wrong.
+
+**Which notebook cell / step?**
+e.g. "Cell 4: Massive Virtual Screening (SBVS)"
+
+**To reproduce**
+Steps to reproduce the behavior, including the paths/parameters you used.
+
+**Expected behavior**
+What you expected to happen.
+
+**Error output**
+```
+Paste the full error message or log here.
+```
+
+**Environment**
+- OS (e.g. Windows 11 + WSL2 Ubuntu 22.04):
+- How you installed the environment (environment.yml / manual):
+- CPU and RAM:
+- Number of ligands being screened:
+
+**Additional context**
+Anything else that might help.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea or improvement for the pipeline
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+**What problem does this solve?**
+Describe the use case or limitation you're running into.
+
+**Proposed solution**
+What you'd like to see happen.
+
+**Alternatives considered**
+Any other approaches you've thought about.
+
+**Additional context**
+Links, references, or examples that help explain the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Description
+
+Briefly describe what this pull request changes and why.
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Other (please describe):
+
+## Checklist
+
+- [ ] My change is focused on a single logical topic.
+- [ ] If I edited `pipeline_SBVS.ipynb`, I cleared all cell outputs before committing.
+- [ ] I did not commit any local paths, ligand data, or result files.
+- [ ] I tested the affected notebook cell(s) with a small ligand set.
+- [ ] I updated the README / documentation if behavior changed.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Generated helper scripts written by the notebook cells
+prepare_library.py
+run_sbvs.py
+run_redocking.py
+config_vina.txt
+
+# Docking inputs / outputs
+*.pdbqt
+*.sdf
+*.mol2
+*.log
+*_log.txt
+*_out.pdbqt
+temp_parallel_prep/
+results/
+data/
+
+# Results tables
+resumen_*.csv
+
+# Python
+__pycache__/
+*.py[cod]
+.ipynb_checkpoints/
+*.egg-info/
+.venv/
+env/
+
+# OS / editor
+.DS_Store
+Thumbs.db
+*.swp
+.idea/
+.vscode/

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+message: "If you use this pipeline in your research, please cite it and the underlying scientific tools (AutoDock Vina, Smina, Meeko, RDKit, Open Babel) listed in the README."
+title: "Local SBVS Pipeline"
+abstract: >-
+  A hybrid Structure-Based Virtual Screening (SBVS) workflow that uses Google
+  Colab as the user interface and a local machine for heavy computation,
+  enabling efficient, resumable, parallelized molecular docking with
+  AutoDock Vina and Smina.
+type: software
+authors:
+  - family-names: "Paredes Alfonso"
+    given-names: "Noé"
+    affiliation: "BIO-HPC, Universidad Católica de Murcia (UCAM)"
+keywords:
+  - virtual-screening
+  - molecular-docking
+  - bioinformatics
+  - autodock-vina
+  - smina
+  - structure-based-drug-design
+  - cheminformatics
+license: MIT
+repository-code: "https://github.com/Paredes0/LocalADVina-SBVS"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to the Local SBVS Pipeline
+
+Thanks for your interest in improving this project! It started as a tool to
+make Structure-Based Virtual Screening more accessible, and contributions of
+any size are welcome.
+
+## Ways to contribute
+
+- **Report a bug** — open an issue describing what you ran, what you expected,
+  and what happened (include error messages and your OS / hardware).
+- **Suggest a feature** — open an issue explaining the use case.
+- **Improve the documentation** — clarifications to the README or notebook
+  markdown cells are very valuable, especially around setup and path handling.
+- **Submit code** — bug fixes or new notebook cells / scripts.
+
+## Setting up the environment
+
+The full toolchain is pinned in [`environment.yml`](environment.yml):
+
+```bash
+micromamba create -f environment.yml
+micromamba activate docking_vina
+```
+
+For the Colab ↔ local-machine connection, create the lightweight
+`colab_connect` environment as described in the
+[README](README.md#4-link-colab-with-the-local-environment).
+
+## Pull request guidelines
+
+1. Fork the repository and create a topic branch.
+2. Keep changes focused — one logical change per pull request.
+3. If you edit `pipeline_SBVS.ipynb`, **clear all cell outputs** before
+   committing (`Kernel → Restart & Clear Output`) to keep diffs readable and
+   avoid committing local paths or result data.
+4. Describe what you changed and why in the PR description.
+5. Make sure the notebook still runs end-to-end with a small test set of
+   ligands.
+
+## Coding notes
+
+- The notebook generates helper scripts (`prepare_library.py`, `run_sbvs.py`,
+  `run_redocking.py`) at runtime; these are git-ignored. Edit the generating
+  cell, not the generated file.
+- Prefer `subprocess` argument lists over shell strings for new docking calls.
+- Keep user-facing prompts and messages consistent in language within a cell.
+
+## Code of conduct
+
+Be respectful and constructive. We want this to be a welcoming project for
+students and researchers regardless of experience level.

--- a/README.md
+++ b/README.md
@@ -56,26 +56,50 @@ chmod +x bin/micromamba
 
 Create a virtual environment with all the necessary bioinformatics tools.
 
+> **Important:** the notebook cells run their commands inside an environment
+> named **`docking_vina`**. Use exactly this name, or the cells will not find
+> your tools.
+
+#### Option A — One command (recommended)
+
+A pinned [`environment.yml`](environment.yml) is provided so you can build the
+whole toolchain in a single step:
+
 ```bash
-# Create the environment
-micromamba create -n docking_env
+# Create the environment from the file (it is named docking_vina)
+micromamba create -f environment.yml
 
 # Activate the environment
-micromamba activate docking_env
+micromamba activate docking_vina
+```
 
-# Install packages from conda-forge channel and pip
-micromamba install -c conda-forge numpy swig boost-cpp libboost tqdm rdkit meeko openbabel
+#### Option B — Manual installation
+
+```bash
+# Create the environment
+micromamba create -n docking_vina
+
+# Activate the environment
+micromamba activate docking_vina
+
+# Install packages from the conda-forge and bioconda channels, plus pip
+micromamba install -c conda-forge -c bioconda numpy pandas swig boost-cpp libboost tqdm rdkit meeko openbabel smina
 pip install vina
 
 ```
+
+> **Why these packages?** `rdkit`, `meeko` and `openbabel` prepare and convert
+> molecules; `vina` and `smina` run the docking; `pandas` and `tqdm` are
+> imported by the screening scripts the notebook generates. Installing them all
+> now avoids errors part-way through a long run.
 
 ### 4. Link Colab with the Local Environment
 
 To connect the Colab interface with the power of your machine, you need to start a Jupyter server.
 
 ```bash
-# If you are still in the docking_env environment, you must exit it
-micromamba deactivate docking_env
+# If you are still in the docking_vina environment, you must exit it
+micromamba deactivate docking_vina
 
 # Create the environment
 micromamba create -n colab_connect
@@ -99,7 +123,7 @@ Follow the instructions in the terminal to obtain the URL with the token and con
 
 The first thing you must do before anything else is download the `.ipynb` file and upload it to Google Colab via --> "File -> Upload notebook" and select the file.
 
-Once you have both environments installed (`docking_env` and `colab_connect`) with all packages installed, you will only have to perform the previous step without needing to install JupyterLab again; just activate the `colab_connect` environment, start the Jupyter server, and paste it into Google Colab to connect.
+Once you have both environments installed (`docking_vina` and `colab_connect`) with all packages installed, you will only have to perform the previous step without needing to install JupyterLab again; just activate the `colab_connect` environment, start the Jupyter server, and paste it into Google Colab to connect.
 
 ```bash
 # Activate the environment
@@ -110,7 +134,7 @@ jupyter lab --no-browser --NotebookApp.allow_origin='https://colab.research.goog
 
 ```
 
-The `docking_env` environment will work by executing orders sent from the Google Colab notebook to the JupyterLab server. You do not need to connect to it from the terminal; just leave the `colab_connect` environment active and the server started.
+The `docking_vina` environment will work by executing orders sent from the Google Colab notebook to the JupyterLab server. You do not need to connect to it from the terminal; just leave the `colab_connect` environment active and the server started.
 
 ### 6. File Organization and Paths
 
@@ -209,6 +233,20 @@ Performance tests show notable efficiency:
 | **JupyterLab** | Server for remote connection |
 | **Google Colab** | User interface and control |
 
+## 🤝 Contributing
+
+Contributions, bug reports, and ideas are welcome! Please read
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for how to set up the environment and open
+issues or pull requests. There are issue templates for bug reports and feature
+requests to help you get started.
+
+## 📚 How to Cite
+
+If this pipeline is useful in your research, please cite it (see
+[`CITATION.cff`](CITATION.cff)) **and** the underlying scientific tools listed
+in the [Acknowledgements](#acknowledgements-licenses-and-responsibilities)
+section below.
+
 ## 📄 License
 
 Distributed under the MIT License. See the `LICENSE` file for more information.
@@ -218,7 +256,7 @@ Distributed under the MIT License. See the `LICENSE` file for more information.
 **Noé Paredes Alfonso**
 
 * **GitHub**: [Paredes0](https://github.com/Paredes0)
-* **LinkedIn**: [Your Profile](https://www.linkedin.com/in/no%C3%A9-paredes-alfonso-395328267/)
+* **LinkedIn**: [Noé Paredes Alfonso](https://www.linkedin.com/in/no%C3%A9-paredes-alfonso-395328267/)
 
 ## Acknowledgements, Licenses, and Responsibilities
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,28 @@
+# Reproducible environment for the Local SBVS Pipeline.
+#
+# Create it with:
+#     micromamba create -f environment.yml
+#     micromamba activate docking_vina
+#
+# This single environment contains every tool the notebook cells invoke
+# (mk_prepare_ligand.py, mk_prepare_receptor.py, vina, smina, obabel) plus
+# the Python libraries the generated scripts import (rdkit, pandas, tqdm).
+name: docking_vina
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python>=3.10
+  - numpy
+  - pandas
+  - swig
+  - boost-cpp
+  - libboost
+  - tqdm
+  - rdkit
+  - meeko
+  - openbabel
+  - smina
+  - pip
+  - pip:
+      - vina


### PR DESCRIPTION
- Fix environment-name mismatch: README created 'docking_env' but every
  notebook cell runs in 'docking_vina'; standardize on 'docking_vina'
- Add missing pandas and smina to the install instructions (the generated
  screening scripts import pandas and call smina)
- Add environment.yml for one-command, reproducible setup
- Add .gitignore for generated scripts, docking I/O, and result files
- Add CITATION.cff so the pipeline and its tools can be cited
- Add CONTRIBUTING.md, issue templates, and a PR template
- Fix LinkedIn placeholder label and add Contributing/How-to-Cite sections